### PR TITLE
fix issue with unhandled catch in fetch adapter

### DIFF
--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -61,6 +61,9 @@ module.exports = function fetchAdapter(config) {
           request: request
         };
         settle(resolve, reject, res);
+      })
+      .catch(function(error) {
+        reject(error);
       });
     });
   });

--- a/lib/adapters/fetch.js
+++ b/lib/adapters/fetch.js
@@ -61,10 +61,9 @@ module.exports = function fetchAdapter(config) {
           request: request
         };
         settle(resolve, reject, res);
-      })
-      .catch(function(error) {
-        reject(error);
       });
+    }).catch(function(error) {
+        reject(error);
     });
   });
 };


### PR DESCRIPTION
I have implemented catch() func as well.
Some errors like 'TypeError: Network request failed' will cause "Possible unhandled promise rejection" exception.